### PR TITLE
Add libff and libfqfft, previously part of libsnark.

### DIFF
--- a/sourcemap
+++ b/sourcemap
@@ -10,6 +10,8 @@ iproute2 git git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.g
 krb5 git https://github.com/krb5/krb5.git
 libarchive git https://github.com/libarchive/libarchive.git
 libc++ svn http://llvm.org/svn/llvm-project/libcxx/trunk
+libff git https://github.com/scipr-lab/libff.git
+libfqfft git https://github.com/scipr-lab/libfqfft.git
 libsdl hg https://hg.libsdl.org/SDL
 libsnark git https://github.com/scipr-lab/libsnark.git
 libstdc++ svn svn://gcc.gnu.org/svn/gcc/trunk/libstdc++-v3

--- a/sourcemap
+++ b/sourcemap
@@ -22,6 +22,7 @@ mediawiki git https://gerrit.wikimedia.org/r/p/mediawiki/core
 mosh git https://github.com/mobile-shell/mosh.git
 musl git git://git.musl-libc.org/musl
 nethack git git://git.code.sf.net/p/nethack/NetHack
+nettle git https://git.lysator.liu.se/nettle/nettle.git
 numpy git https://github.com/numpy/numpy.git
 openafs git git://git.openafs.org/openafs.git
 openldap git git://git.openldap.org/openldap.git


### PR DESCRIPTION
libsnark was split into three libraries; this commit adds xref monitoring for libff (finite fields and elliptic curves), and libfqfft (finite field FFTs).